### PR TITLE
Updated pa11y-ci version and pa11y config to fix the failing build

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -19,10 +19,8 @@ const urls = [
 
 const config = {
 	defaults: {
-		page: {
-			headers: {
-				'Cookie': 'next-flags=ads:off,cookieMessage:off; secure=true'
-			}
+		headers: {
+			'Cookie': 'next-flags=ads:off,cookieMessage:off; secure=true'
 		},
 		timeout: 25000,
 		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
@@ -37,9 +35,7 @@ for (const viewport of viewports) {
 
 		config.urls.push({
 			url: url,
-			page: {
-				viewport: viewport
-			},
+			viewport: viewport,
 			screenCapture: `./pa11y_screenCapture/${path}.png`
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Financial-Times/kat-footer.git"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^2.0.2",
+    "@financial-times/n-gage": "^2.0.4",
     "@financial-times/n-heroku-tools": "^7.4.0",
     "@financial-times/n-internal-tool": "^2.2.1",
     "bower": "^1.7.9",
@@ -18,7 +18,7 @@
     "lintspaces-cli": "^0.6.0",
     "npm-prepublish": "^1.2.3",
     "origami-build-tools": "^5.5.3",
-    "pa11y-ci": "^1.3.0",
+    "pa11y-ci": "^2.1.1",
     "sass-lint": "^1.12.1"
   },
   "scripts": {


### PR DESCRIPTION
Builds for apps that use `pa11y-ci@^1.xx` started to fail since CircleCI has removed PhantomJS from the Docker image we are using to build our apps.

This can be fixed by updating the `pa11y-ci` and `n-gage` to the latest versions. For apps that use a custom pa11y config, the `.pa11yci.js` file also needs an update.

🐿 v2.10.3